### PR TITLE
Add AdminChat

### DIFF
--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -18,7 +18,8 @@ import {
   Chat,
   UserInfoTypeInput,
   ChatUserInfo,
-  Permission
+  Permission,
+  AdminChat
 } from './types/schema-types';
 import { genID, getHash, asyncForEach } from './helper';
 
@@ -108,6 +109,7 @@ class FireBaseSVC {
       await newUser.updateProfile( { displayName: `${firstName} ${lastName}`})
       return true;
     } catch(e) {
+      console.log('error creating user', e)
       return false;
     }
   }
@@ -158,6 +160,10 @@ class FireBaseSVC {
   }
 
   async pushUser(firstName, lastName, email, userType, phoneNumber, hash, groupID, gender) {
+    // maybe create an admin chat option?
+    const adminChat: AdminChat = {
+      chatID: genID()
+    }
     const user_and_id: UserInfoType = {
       firstName,
       lastName,
@@ -169,7 +175,8 @@ class FireBaseSVC {
       chatIDs: [],
       classes: [],
       groupID,
-      gender
+      gender,
+      adminChat
     }
     await this._refUserID(hash).update(user_and_id);
     const curFam = await this._refFamily(groupID).once('value').then(snap => {

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -58,6 +58,8 @@ const resolvers = {
             groupID,
             gender
           )
+          console.log('res', resp, result)
+
           response = resp && result;
         })
       }

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -58,8 +58,6 @@ const resolvers = {
             groupID,
             gender
           )
-          console.log('res', resp, result)
-
           response = resp && result;
         })
       }

--- a/schema.ts
+++ b/schema.ts
@@ -119,6 +119,7 @@ const typeDefs = gql`
     classes: [Chat]
     groupID: String!
     gender: String!
+    adminChat: AdminChat!
   }
 
   type ChatUserInfo {
@@ -150,6 +151,13 @@ const typeDefs = gql`
     # tutorEmail: String!
     tutorInfo: ChatUserInfo!
     # where are we keeping these messages
+    chatID: String!
+  }
+
+  # this will serve as the chat with shweta and sakthi
+  # only field we need is the chatID right?
+  # mmembers are already decided: user, shweta, sakthi
+  type AdminChat {
     chatID: String!
   }
 

--- a/types/schema-types.d.ts
+++ b/types/schema-types.d.ts
@@ -117,11 +117,13 @@ export type UserInfoType = {
   classes?: Maybe<Array<Maybe<Chat>>>;
   groupID: Scalars['String'];
   gender: Scalars['String'];
+  adminChat: AdminChat;
 };
 
 export type ChatUserInfo = {
   __typename?: 'ChatUserInfo';
-  name: Scalars['String'];
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
   email: Scalars['String'];
 };
 
@@ -137,6 +139,11 @@ export type Chat = {
   className: Scalars['String'];
   userInfo: Array<ChatUserInfo>;
   tutorInfo: ChatUserInfo;
+  chatID: Scalars['String'];
+};
+
+export type AdminChat = {
+  __typename?: 'AdminChat';
   chatID: Scalars['String'];
 };
 
@@ -239,8 +246,9 @@ export type Mutation = {
   deleteClass: DeleteClassPayload;
   createChat: CreateChatPayload;
   createCode: CreateCodePayload;
-  updateUser: GenericResponse;
   addFamilyMember: GenericResponse;
+  deleteChat: GenericResponse;
+  updateUser: GenericResponse;
 };
 
 
@@ -283,14 +291,19 @@ export type MutationCreateCodeArgs = {
 };
 
 
-export type MutationUpdateUserArgs = {
-  user: UserInfoTypeInput;
-};
-
-
 export type MutationAddFamilyMemberArgs = {
   familyID: Scalars['String'];
   userEmails: Array<Scalars['String']>;
+};
+
+
+export type MutationDeleteChatArgs = {
+  chatID: Scalars['String'];
+};
+
+
+export type MutationUpdateUserArgs = {
+  user: UserInfoTypeInput;
 };
 
 export type Subscription = {


### PR DESCRIPTION
so this is my implementation for creating the admin chat page. 

I created a separate field (`AdminChat`) on the `User` instead of creating a `Chat` and adding it to `classes` right at user creation because

1. the fields on `Chat` are not relevant to the use case of the `AdminChat`. fields like the `className` and the tutor and user email fields do not make sense here. these are no longer dynamic fields and would only include Shweta and Sakthi as well as the current user.

2. I do not want this chat to be showing up in the `ChatPicker` component as that place is meant to be for specific classes. The `AdminChat` is meant to be used for a general purpose chat

