### PR TITLE
Add env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 config/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-config/
+config/private-key.json
 .env

--- a/config/EmailInfo.ts
+++ b/config/EmailInfo.ts
@@ -1,0 +1,2 @@
+export const REQUEST_EMAIL = process.env.REQUEST_EMAIL;
+export const REQUEST_EMAIL_PASSWORD = process.env.REQUEST_EMAIL_PASSWORD;

--- a/config/firebaseAdminConfig.ts
+++ b/config/firebaseAdminConfig.ts
@@ -2,7 +2,7 @@ export const FIREBASE_ADMIN_CONFIG: Object = {
   type: process.env.TYPE,
   project_id: process.env.PROJECT_ID,
   private_key_id: process.env.PRIVATE_KEY_ID,
-  private_key: process.env.PRIVATE_KEY,
+  private_key: process.env.PRIVATE_KEY.replace(/\\n/g, '\n'),
   client_email: process.env.CLIENT_EMAIL,
   client_id: process.env.CLIENT_ID,
   auth_uri: process.env.AUTH_URI,

--- a/config/firebaseAdminConfig.ts
+++ b/config/firebaseAdminConfig.ts
@@ -1,0 +1,12 @@
+export const FIREBASE_ADMIN_CONFIG: Object = {
+  type: process.env.TYPE,
+  project_id: process.env.PROJECT_ID,
+  private_key_id: process.env.PRIVATE_KEY_ID,
+  private_key: process.env.PRIVATE_KEY,
+  client_email: process.env.CLIENT_EMAIL,
+  client_id: process.env.CLIENT_ID,
+  auth_uri: process.env.AUTH_URI,
+  token_uri: process.env.TOKEN_URI,
+  auth_provider_x509_cert_url: process.env.AUTH_PROVIDER_X509_CERT_URL,
+  client_x509_cert_url: process.env.CLIENT_X509_CERT_URL
+}

--- a/config/firebaseConfig.ts
+++ b/config/firebaseConfig.ts
@@ -1,0 +1,10 @@
+export const firebaseConfig = {
+  apiKey: process.env.API_KEY,
+  authDomain: process.env.AUTH_DOMAIN,
+  databaseURL: process.env.DATABASE_URL,
+  projectId: process.env.PROJECT_ID,
+  storageBucket: process.env.STORAGE_BUCKET,
+  messagingSenderId: process.env.MESSAGING_SENDER_ID,
+  appId: process.env.APP_ID,
+  measurementId: process.env.MEASUREMENT_ID
+}

--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -38,13 +38,12 @@ import {
   ADMIN_EMAILS,
   ADMIN_EMAIL
 } from './constants';
-const creds = require('./config/private-key.json')
-import { KEY } from './config/private-key';
+import { FIREBASE_ADMIN_CONFIG } from './config/firebaseAdminConfig';
 
 class FireBaseSVC {
   constructor() {
     admin.initializeApp({
-      credential: admin.credential.cert(creds),
+      credential: admin.credential.cert(FIREBASE_ADMIN_CONFIG),
       databaseURL: "https://emphasis-app-41390.firebaseio.com"
     });
     firebase.initializeApp(firebaseConfig);

--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -5,7 +5,7 @@ import nodemailer from 'nodemailer';
 import * as admin from 'firebase-admin';
 
 import pubsub from './pubsub';
-import { firebaseConfig } from './config/firebase';
+import { firebaseConfig } from './config/firebaseConfig';
 import { REQUEST_EMAIL, REQUEST_EMAIL_PASSWORD} from './config/EmailInfo';
 import { MESSAGE_RECEIVED_EVENT, NUM_FETCH_MESSAGES } from './constants';
 import {
@@ -39,6 +39,7 @@ import {
   ADMIN_EMAIL
 } from './constants';
 const creds = require('./config/private-key.json')
+import { KEY } from './config/private-key';
 
 class FireBaseSVC {
   constructor() {

--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -44,7 +44,7 @@ class FireBaseSVC {
   constructor() {
     admin.initializeApp({
       credential: admin.credential.cert(FIREBASE_ADMIN_CONFIG),
-      databaseURL: "https://emphasis-app-41390.firebaseio.com"
+      databaseURL: process.env.DATABASE_URL
     });
     firebase.initializeApp(firebaseConfig);
     console.log('we are initializing');

--- a/firebase_test.ts
+++ b/firebase_test.ts
@@ -1,5 +1,5 @@
 import * as firebase from 'firebase';
-import { firebaseConfig } from './config/firebase';
+import { firebaseConfig } from './config/firebaseConfig';
 
 const firebaseApp = firebase.initializeApp(firebaseConfig);
 export const db = firebaseApp.datebase();

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,8 @@
 import { ApolloServer } from 'apollo-server';
 import express from 'express';
+import * as dotenv from 'dotenv';
 // import { ApolloServer } from 'apollo-server-express';
+dotenv.config();
 
 import typeDefs from './schema';
 import resolvers from './resolvers';
@@ -19,6 +21,6 @@ const server = new ApolloServer({
 // app.use('/', (req, res) => 'hi')
 // app.listen({port: process.env.PORT || 4000}, () => console.log(`server on ${server.graphqlPath}`))
 
-server.listen(process.env.PORT || 4000).then(({ url }) => {
+server.listen(process.env.PORT).then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`);
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "apollo-server-express": "^2.14.1",
     "base-64": "^0.1.0",
     "crypto-js": "^4.0.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "firebase": "^7.14.6",
     "firebase-admin": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,7 +3356,7 @@ dotenv@^4.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
   integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
 
-dotenv@^8.0.0:
+dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
This PR changes the config files to read from the environment variables. Adding the keys and such to source control is not the best idea, so env vars are the best option. I added a local `.env` file and added the `dotenv` library. Then I added the env var values on the heroku side as well.