### PR TITLE
Pre user testing fixes

### DIFF
--- a/datasource.ts
+++ b/datasource.ts
@@ -48,8 +48,8 @@ class dataSource extends RESTDataSource {
     return await firebaseSvc.getFamily(groupID);
   }
 
-  async searchUsers(searchTerm: string) {
-    return await firebaseSvc.searchUsers(searchTerm);
+  async searchUsers(searchTerm: string, includeAdmin?: boolean) {
+    return await firebaseSvc.searchUsers(searchTerm, includeAdmin);
   }
 
   async searchClasses(searchTerm: string) {

--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -527,7 +527,7 @@ class FireBaseSVC {
     return res;
   }
 
-  async searchUsers(searchTerm: string) {
+  async searchUsers(searchTerm: string, includeAdmin?: boolean) {
 
     const relevantFields = [ 'email', 'firstName', 'lastName', 'phoneNumber', 'userType' ];
 
@@ -538,19 +538,19 @@ class FireBaseSVC {
         const keys = Object.keys(val);
         const Users = keys.map((k, index) => {
           const u = val[k];
-          let flag = false;
+          let present = false;
           relevantFields.forEach((_field) => {
             let field = u[_field];
             if (_field === 'email') { field = field.split('@')[0] }
             if (field.toLowerCase().includes(searchTerm.toLowerCase())) {
-              flag = true;
+              present = true;
               return;
             }
           })
-          if (flag) { return u }
+          if (present) { return u }
           // let us filter out the admins
           // only the admins will be searching users and they wont really need to add themselves
-        }).filter(user => !!user).filter(user => user.userType !== 'Admin') //for some reason cannot user Permission.Admin here
+        }).filter(user => !!user).filter(user => includeAdmin || user.userType !== 'Admin') //for some reason cannot user Permission.Admin here
         return Users;
       })
   }
@@ -599,7 +599,6 @@ class FireBaseSVC {
 
   async createChat(displayName: string, className: string, tutorInfo: ChatUserInfo, userInfo: ChatUserInfo[]) {
     // generate chatID / class ID
-    // let us make these two ^ the same
     const chatID: string = genID();
     const tutorID: string = getHash(tutorInfo.email);
     const adminUsers: UserInfoType[] = await Promise.all(ADMIN_EMAILS.map(async _email => {

--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -344,6 +344,8 @@ class FireBaseSVC {
       .once(VALUE)
       .then(snap => {
         const val = snap.val();
+        // return empty list if there are no messages
+        if (!val) { return []}
         const key = Object.keys(val)
         const mess: MessageType[] = key.map(k => {
           return val[k]

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -13,8 +13,8 @@ const resolvers = {
     getFamily: async (_, { groupID }, { dataSources }) => {
       return await dataSources.f.getFamily(groupID)
     },
-    searchUsers: async (_, { searchTerm }, { dataSources}) => {
-      return await dataSources.f.searchUsers(searchTerm)
+    searchUsers: async (_, { searchTerm, includeAdmin }, { dataSources}) => {
+      return await dataSources.f.searchUsers(searchTerm, includeAdmin)
     },
     searchClasses: async (_, { searchTerm }, { dataSources }) => {
       return await dataSources.f.searchClasses(searchTerm)

--- a/schema.ts
+++ b/schema.ts
@@ -139,15 +139,12 @@ const typeDefs = gql`
     email: String!
   }
 
-  # need to look over which fields are required
-  # letf a lot of them to be nullable because at creation we will not know these details
   type Chat {
     # display name
     displayName: String!
     # class name
     className: String!
     # who is taking this class
-    # userEmails: [String]
     userInfo: [ChatUserInfo!]!
     # who is teaching this class (probs will only be on)
     # tutorEmail: String!
@@ -217,7 +214,7 @@ const typeDefs = gql`
     # we also want to know who is getting the messages
     getMessages(chatID: String!, userID: String!, refresh: Boolean): [MessageType]
     getFamily(groupID: String!): [UserInfoType]
-    searchUsers(searchTerm: String!): [UserInfoType]!
+    searchUsers(searchTerm: String!, includeAdmin: Boolean): [UserInfoType]!
     searchClasses(searchTerm: String!): searchClassesPayload!
     getUser(userEmail: String!): UserInfoType!
     checkCode(email: String!, code: String!): genericResponse!

--- a/types/schema-types.d.ts
+++ b/types/schema-types.d.ts
@@ -225,6 +225,7 @@ export type QueryGetFamilyArgs = {
 
 export type QuerySearchUsersArgs = {
   searchTerm: Scalars['String'];
+  includeAdmin?: Maybe<Scalars['Boolean']>;
 };
 
 


### PR DESCRIPTION
Fixes:
- add the `includeAdmin` param to the `searchUsers` query so that we can conditionally query for the admins. This is needed when we are creating a chat. It is a possibility that admins can be tutors for chats, so we need to be able to search and select them at that time.
- return an empty list when there are no messages in a chat. query was failing before.