### PR TITLE
clean out empty classes before returning in getUser

### DIFF
--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -678,7 +678,7 @@ class FireBaseSVC {
         const val = snap.val()
         return val
       })
-    const cleanedOutUser = {...user, classes: user.classes.filter(c => !!c)}
+    const cleanedOutUser = {...user, classes: user.classes?.filter(c => !!c)}
     return cleanedOutUser
   }
 

--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -678,7 +678,8 @@ class FireBaseSVC {
         const val = snap.val()
         return val
       })
-    return user;
+    const cleanedOutUser = {...user, classes: user.classes.filter(c => !!c)}
+    return cleanedOutUser
   }
 
   async getFamily(groupID: string) {


### PR DESCRIPTION
an admin had deleted a chat, but due to the way that chat deletion had happened, i deleted the chat at a specific index, which threw the indexing of the array off.

the chat deletion needs to be modified to re-set the whole array of classes at its ref instead of deleting a specific one at the array.

Then we will get indexes like this: 
![image](https://user-images.githubusercontent.com/31258789/106995589-d68e0200-6744-11eb-8ee7-b77eee4d9b74.png)

and this breaks the `getUser` query
 