### PR TITLE
revert to old query

### DIFF
--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -759,7 +759,7 @@ class FireBaseSVC {
   //   return await this._refChatNotification(userID, chatID).once(VALUE).then(snap => snap.val())
   // }
 
-  async _getUser(email: string, fcmToken?: string): Promise<GetUserPayload> {
+  async _getUser(email: string, fcmToken?: string): Promise<UserInfoType> {
     if (fcmToken) {
       await this.updateFCMTokens(email, fcmToken);
     }
@@ -772,10 +772,11 @@ class FireBaseSVC {
         isAdmin: chatNotifObject[chatID].isAdmin
       }
     )) : []
-    return {
-      user,
-      chatNotifications: convertedArr
-    }
+    // return {
+    //   user,
+    //   chatNotifications: convertedArr
+    // }
+    return user
   }
 
   // lets pass in the email and then hash it here

--- a/schema.ts
+++ b/schema.ts
@@ -239,7 +239,8 @@ const typeDefs = gql`
     getFamily(groupID: String!): [UserInfoType]
     searchUsers(searchTerm: String!, includeAdmin: Boolean): [UserInfoType]!
     searchClasses(searchTerm: String!): searchClassesPayload!
-    getUser(userEmail: String!, fcmToken: String): getUserPayload!
+    # getUser(userEmail: String!, fcmToken: String): getUserPayload!
+    getUser(userEmail: String!, fcmToken: String): UserInfoType!
     checkCode(email: String!, code: String!): genericResponse!
   }
 

--- a/types/schema-types.d.ts
+++ b/types/schema-types.d.ts
@@ -227,7 +227,7 @@ export type Query = {
   getFamily?: Maybe<Array<Maybe<UserInfoType>>>;
   searchUsers: Array<Maybe<UserInfoType>>;
   searchClasses: SearchClassesPayload;
-  getUser: GetUserPayload;
+  getUser: UserInfoType;
   checkCode: GenericResponse;
 };
 


### PR DESCRIPTION
By mistake, updates to the getUser query (in https://github.com/adithyaBellary/emphasis_education_server/pull/36) got merged to master before the updated app version was released.

this hotfix needed to go in to allow the current app version to continue querying for the user.

The new getUser scheme needs to go in at the same time as the app version bump in a coordinated fashion.