### PR TITLE
Fix duplicate notifications for the same message

### DIFF
--- a/firebaseSvc.ts
+++ b/firebaseSvc.ts
@@ -4,6 +4,7 @@ import { MD5 } from "crypto-js"
 import nodemailer from 'nodemailer';
 import * as admin from 'firebase-admin';
 import * as Sentry from '@sentry/node';
+import * as _ from 'lodash';
 
 import pubsub from './pubsub';
 import { firebaseConfig } from './config/firebaseConfig';
@@ -49,8 +50,6 @@ import {
   CHAT_NOTIFICATION
 } from './constants';
 import { FIREBASE_ADMIN_CONFIG } from './config/firebaseAdminConfig';
-import { access } from 'fs';
-
 class FireBaseSVC {
 
   public state: { transporter: any } = {
@@ -685,8 +684,6 @@ class FireBaseSVC {
         ...chatUsers,
         ...adminUserInfo,
       ].filter(_user => _user.email !== senderUserInfo.email)
-      console.log('send user info', senderUserInfo)
-      console.log('relUsers:', relUsers)
     }
 
     const _runAsync = async () => {
@@ -708,8 +705,14 @@ class FireBaseSVC {
     await _runAsync();
 
     const fcms: FcmDeviceToken[] = await this._refFCMDeviceTokensPerChat(_chatID).once(VALUE).then(snap => snap.val())
+    // the issue regarding multiple notifications being sent for the same message
+    // is most likely a product of duplicate objects in the `fcms` array.
+    // I have not been able to find evidence of this in the db, but this unique constraint
+    // should catch any discrepancies
+    const uniqFCMs = _.uniq(fcms)
+
     // let us not send fcm messages to the sender themself
-    const fcmTokens = fcms.filter(f => f.email !== senderUserInfo.email).map(token => token.token)
+    const fcmTokens = uniqFCMs.filter(f => f.email !== senderUserInfo.email).map(token => token.token)
     const relevantUserEmails = relUsers.map(_user => _user.email).join(',')
     const notificationTitle = isAdminMessage ? 'New Admin Chat Message' : `New Message in ${chatObject.className}`
     admin.messaging().sendToDevice(

--- a/index.ts
+++ b/index.ts
@@ -25,8 +25,6 @@ const server = new ApolloServer({
   resolvers,
   subscriptions: {
     onConnect: (connectionParams, webSocket) => {
-      console.log('connectionParams', connectionParams)
-      console.log('webSocket', !!webSocket)
       return true
     },
     onDisconnect: (websocket, context) => {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@sentry/node": "^5.25.0",
     "@sentry/tracing": "^5.25.0",
     "@types/crypto-js": "^3.1.47",
+    "@types/lodash": "^4.14.176",
     "apollo-datasource-rest": "^0.9.2",
     "apollo-server": "^2.14.1",
     "apollo-server-express": "^2.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,6 +1729,11 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
+"@types/lodash@^4.14.176":
+  version "4.14.176"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
+  integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
+
 "@types/long@^4.0.0", "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"


### PR DESCRIPTION
Was seeing reports of duplicate notifications being sent for the same message. When debugging, manually including two of the same `fcm` tokens caused multiple notifications to be pushed (which makes sense to me)

Added a unique constraint to the fcm tokens being pushed to as a fallback. Could not find instances in the DB of multiple fcm tokens, however, so unsure how multiple tokens are being pushed to the DB in the first place. 